### PR TITLE
Add Lord Baybrooke as MARC censor

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -97,6 +97,7 @@
 		<meta property="se:url.encyclopedia.wikipedia" refines="#annotator-1">https://en.wikipedia.org/wiki/Richard_Griffin,_3rd_Baron_Braybrooke</meta>
 		<meta property="se:url.authority.nacoaf" refines="#annotator-1">https://id.loc.gov/authorities/names/n50014973</meta>
 		<meta property="role" refines="#annotator-1" scheme="marc:relators">ann</meta>
+		<meta property="role" refines="#annotator-1" scheme="marc:relators">cns</meta>
 		<meta property="role" refines="#annotator-1" scheme="marc:relators">ill</meta>
 		<dc:contributor id="transcriber-1">David Widger</dc:contributor>
 		<meta property="file-as" refines="#transcriber-1">Widger, David</meta>


### PR DESCRIPTION
I found `cns` in the list of MARC relators, and considering Lord Baybrooke liberally censored large chunks of the Diary (which were only partially restored for this edition) I think it’s a reasonable tag to add. Not worth a republish, but a nice historical note.